### PR TITLE
wayland support (rough)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -21,8 +21,16 @@ cp -r dist-dark $DEST_DIR/Graphite-dark-cursors
 cp -r dist-light-nord $DEST_DIR/Graphite-light-nord-cursors
 cp -r dist-dark-nord $DEST_DIR/Graphite-dark-nord-cursors
 
-# if $XDG_SESSION_TYPE == 'wayland' :
-#  echo 'export XCURSOR_PATH=${XCURSOR_PATH}:~/.local/share/icons' | ~/.bash_profile
+if [[ $XDG_SESSION_TYPE = "wayland" ]]
+then
+  echo "Add XWayland compatibility to .bash_profile?"
+  select yn in "Yes" "No"; do
+    case $yn in
+        Yes ) echo 'export XCURSOR_PATH=${XCURSOR_PATH}:~/.local/share/icons' >> ~/.bash_profile; break;;
+        No ) exit;;
+    esac
+done
+fi
 
 echo "Finished..."
 

--- a/install.sh
+++ b/install.sh
@@ -27,7 +27,7 @@ then
   select yn in "Yes" "No"; do
     case $yn in
         Yes ) echo 'export XCURSOR_PATH=${XCURSOR_PATH}:~/.local/share/icons' >> ~/.bash_profile; break;;
-        No ) exit;;
+        No ) break;;
     esac
 done
 fi

--- a/install.sh
+++ b/install.sh
@@ -21,5 +21,8 @@ cp -r dist-dark $DEST_DIR/Graphite-dark-cursors
 cp -r dist-light-nord $DEST_DIR/Graphite-light-nord-cursors
 cp -r dist-dark-nord $DEST_DIR/Graphite-dark-nord-cursors
 
+# if $XDG_SESSION_TYPE == 'wayland' :
+#  echo 'export XCURSOR_PATH=${XCURSOR_PATH}:~/.local/share/icons' | ~/.bash_profile
+
 echo "Finished..."
 


### PR DESCRIPTION
I do not know how to bash script, but have provided the method to enable the cursors on Wayland using XWayland.

I hope the basic idea is understandable though, XCURSOR_PATH=${XCURSOR_PATH}:~/.local/share/icons makes XWayland use the cursors

> Environment variable

>You can use an environment variable to set a theme for a single application to try it out temporarily, for example:

>$ XCURSOR_THEME=SomeThemeName xclock

>XCURSOR_SIZE is optional if your cursor theme supports multiple sizes.

>If cursor themes are installed in ~/.local/share/icons, in order to avoid possible issues, add that path to XCURSOR_PATH. For example:

>~/.bash_profile

>export XCURSOR_PATH=${XCURSOR_PATH}:~/.local/share/icons